### PR TITLE
Use standard module importlib.metadata

### DIFF
--- a/src/streamlit_vizzu/chart.py
+++ b/src/streamlit_vizzu/chart.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from importlib_metadata import version
+from importlib.metadata import version
 from distutils.version import StrictVersion
 import uuid
 


### PR DESCRIPTION
Shipped natively with python since 3.8

Should fix https://intro-to-vizzu-in.streamlit.app/